### PR TITLE
fix(fn-if): add positional arguments to match the original fn helper

### DIFF
--- a/addon/helpers/fn-if.js
+++ b/addon/helpers/fn-if.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 
-export function fnIf([condition, invokeable]/*, hash*/) {
+export function fnIf([condition, invokeable, ...args]/*, hash*/) {
   if (condition) {
-    return invokeable;
+    return () => invokeable(...args);
   }
 
   return () => {};

--- a/addon/helpers/fn-if.js
+++ b/addon/helpers/fn-if.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 export function fnIf([condition, invokeable, ...args]/*, hash*/) {
   if (condition) {
-    return () => invokeable(...args);
+    return (...extra) => invokeable(...args, ...extra);
   }
 
   return () => {};


### PR DESCRIPTION
Added the ability to pass positional arguments to `{{fn-if}}` match the original `{{fn}}` helper.
Currently, any extra arguments are ignored.

Example:
```hbs
<button {{(on "click" (fn-if this.condition this.track "extra data"))}}>
  Checkout!
</button>
```
`"extra data"` will not be ignored and will be the first argument for `this.track` function.